### PR TITLE
Improve generate function name

### DIFF
--- a/lib/convert-swagger-to-configs.js
+++ b/lib/convert-swagger-to-configs.js
@@ -114,8 +114,10 @@ var extractFunctionName = function extractFunctionName(definition, options) {
     return (/^\{.*\}$/.test(w)
     );
   }).map(function (w, i) {
-    var n = changeCase.pascalCase(w.split(1, -1));
-    return i === 0 ? 'With' + n : 'And' + n;
+    var n = changeCase.dotCase(w.slice(1, -1)).split('.').map(function (s) {
+      return changeCase.pascalCase(s.slice(0, 3));
+    }).join('');
+    return i === 0 ? 'With' + n : n;
   });
 
   return method.concat(resources, conditions).join('');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-import-swagger",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Import functions from swagger spec filet to serverless.yml",
   "bin": {
     "sis": "./bin/sis"

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,7 +12,7 @@ const wrilteFile = require('./write-file');
 
 module.exports.exec = () => {
   commander
-  .version('0.0.13')
+  .version('0.0.14')
   .description('Import functions from swagger spec filet to serverless.yml')
   .option('-i, --input <path>', 'Specify swagger file path. (defailt "./swagger.ya?ml")')
   .option('-c, --common <path>', 'Specify common config of serverless file path. (default "./serverless.common.ya?ml")')

--- a/src/convert-swagger-to-configs.js
+++ b/src/convert-swagger-to-configs.js
@@ -105,8 +105,11 @@ const extractFunctionName = (definition, options) => {
   .filter(w => (w.length > 0))
   .filter(w => /^\{.*\}$/.test(w))
   .map((w, i) => {
-    const n = changeCase.pascalCase(w.split(1, -1));
-    return (i === 0) ? `With${n}` : `And${n}`;
+    const n = changeCase.dotCase(w.slice(1, -1))
+    .split('.')
+    .map(s => changeCase.pascalCase(s.slice(0, 3)))
+    .join('');
+    return (i === 0) ? `With${n}` : n;
   });
 
   return method.concat(resources, conditions).join('');

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ describe('sis', () => {
 
   describe('interface testing', () => {
     before(() => {
-      const command = `${appRoot.path}/bin/sis -i test/swagger.yaml -c test/serverless.common.yml -S sis -O -f -o test/src`;
+      const command = `${appRoot.path}/bin/sis -i test/swagger.yaml -c test/serverless.common.yml -S sis -B -O -f -o test/src`;
       childProcess.execSync(command);
     });
 


### PR DESCRIPTION
関数名生成ロジックを改良。
コンディションの単語を3文字目までにカットする処理を入れるとともに、`And`の挿入をやめて長い関数名が生成されづらいようにした。