### PR TITLE
Implementation organize around CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,23 @@ Usage: sis [options]
 
     -h, --help                     output usage information
     -V, --version                  output the version number
+
+    # Common options.
     -i, --input <path>             Specify swagger file path. (defailt "./swagger.ya?ml")
     -c, --common <path>            Specify common config of serverless file path. (default "./serverless.common.ya?ml")
     -o, --out-dir <path>           Specify dist directory of services. (default "./")
+    -f, --force                    If add this option, overwriten serverless.yml by generated definitinos.
+
+    # Services and tags prefix options.
     -A, --api-prefix <prefix>      Specify target prefix for swagger tags. (default "sls")
     -S, --service-prefix <prefix>  Specify prefix that added service name. (default none)
+
+    # Base path mode that spliting large api specification settings.
     -B, --base-path                If add this option, run in a mode of dividing a service by a api base path.
-    -f, --force                    If add this option, overwriten serverless.yml by generated definitinos.
+
+    # CORS and OPTIONS method settings.
+    -C, --cors                     If add this option, added cors setting to all http event.
+    -O, --options-method           If add this option, added cors setting to get http event, and added OPTIONS method to api path that including other http method.
 ```
 
 Example

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,7 +15,15 @@ var mergeConfigs = require('./merge-configs');
 var wrilteFile = require('./write-file');
 
 module.exports.exec = function () {
-  commander.version('0.0.13').description('Import functions from swagger spec filet to serverless.yml').option('-i, --input <path>', 'Specify swagger file path. (defailt "./swagger.ya?ml")').option('-c, --common <path>', 'Specify common config of serverless file path. (default "./serverless.common.ya?ml")').option('-o, --out-dir <path>', 'Specify dist directory of services. (default "./")').option('-A, --api-prefix <prefix>', 'Specify target prefix for swagger tags. (default "sls")').option('-S, --service-prefix <prefix>', 'Specify prefix that added service name. (default none)').option('-B, --base-path', 'If add this option, run in a mode of dividing a service by a api base path.').option('-f, --force', 'If add this option, overwriten serverless.yml by generated definitinos.').option('-C, --cors', 'If add this option, added cors setting to all event.').option('-O, --options-method', 'If add this option, added OPTIONS method for all api path.').parse(process.argv);
+  commander.version('0.0.15').description('Import functions from swagger spec filet to serverless.yml')
+  // Common options.
+  .option('-i, --input <path>', 'Specify swagger file path. (defailt "./swagger.ya?ml")').option('-c, --common <path>', 'Specify common config of serverless file path. (default "./serverless.common.ya?ml")').option('-o, --out-dir <path>', 'Specify dist directory of services. (default "./")').option('-f, --force', 'If add this option, overwriten serverless.yml by generated definitinos.')
+  // Services and tags prefix options.
+  .option('-A, --api-prefix <prefix>', 'Specify target prefix for swagger tags. (default "sls")').option('-S, --service-prefix <prefix>', 'Specify prefix that added service name. (default none)')
+  // Base path mode settings.
+  .option('-B, --base-path', 'If add this option, run in a mode of dividing a service by a api base path.')
+  // CORS and options settings.
+  .option('-C, --cors', 'If add this option, added cors setting to all http event.').option('-O, --options-method', 'If add this option, added cors setting to get http event, and added OPTIONS method to api path that including other http method.').parse(process.argv);
 
   var options = {
     input: commander.input ? commander.input : 'swagger.yaml',

--- a/lib/convert-swagger-to-configs.js
+++ b/lib/convert-swagger-to-configs.js
@@ -17,18 +17,23 @@ var swaggerToDefinitions = function swaggerToDefinitions(swagger, options) {
     Object.keys(swagger.paths[path]).forEach(function (method) {
       definitions.push({
         path: path,
-        method: method,
+        method: method.toLowerCase(),
         methodObject: swagger.paths[path][method]
       });
+    });
 
-      if (options.optionsMethod) {
+    if (options.optionsMethod) {
+      var filtered = Object.keys(swagger.paths[path]).filter(function (method) {
+        return method.toLowerCase() !== 'get';
+      });
+      if (filtered.length > 0) {
         definitions.push({
           path: path,
           method: 'options',
-          methodObject: swagger.paths[path][method]
+          methodObject: swagger.paths[path][filtered[0]]
         });
       }
-    });
+    }
   });
 
   return definitions;
@@ -60,12 +65,12 @@ var definitionToConfig = function definitionToConfig(definition, options) {
   var httpEvent = {
     http: {
       path: path,
-      method: definition.method.toLowerCase(),
+      method: definition.method,
       integration: 'lambda-proxy'
     }
   };
 
-  if (options.cors && !options.options) {
+  if (options.cors || options.optionsMethod && definition.method === 'get') {
     httpEvent.http['cors'] = true;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-import-swagger",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Import functions from swagger spec filet to serverless.yml",
   "bin": {
     "sis": "./bin/sis"
@@ -12,7 +12,7 @@
     "deepmerge": "^1.3.2",
     "graceful-fs": "^4.1.10",
     "js-yaml": "^3.6.1",
-    "serverless": "^1.3.0",
+    "serverless": "^1.9.0",
     "swagger-parser": "^3.4.1"
   },
   "devDependencies": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,17 +12,21 @@ const wrilteFile = require('./write-file');
 
 module.exports.exec = () => {
   commander
-  .version('0.0.14')
+  .version('0.0.15')
   .description('Import functions from swagger spec filet to serverless.yml')
+  // Common options.
   .option('-i, --input <path>', 'Specify swagger file path. (defailt "./swagger.ya?ml")')
   .option('-c, --common <path>', 'Specify common config of serverless file path. (default "./serverless.common.ya?ml")')
   .option('-o, --out-dir <path>', 'Specify dist directory of services. (default "./")')
+  .option('-f, --force', 'If add this option, overwriten serverless.yml by generated definitinos.')
+  // Services and tags prefix options.
   .option('-A, --api-prefix <prefix>', 'Specify target prefix for swagger tags. (default "sls")')
   .option('-S, --service-prefix <prefix>', 'Specify prefix that added service name. (default none)')
+  // Base path mode settings.
   .option('-B, --base-path', 'If add this option, run in a mode of dividing a service by a api base path.')
-  .option('-f, --force', 'If add this option, overwriten serverless.yml by generated definitinos.')
-  .option('-C, --cors', 'If add this option, added cors setting to all event.')
-  .option('-O, --options-method', 'If add this option, added OPTIONS method for all api path.')
+  // CORS and options settings.
+  .option('-C, --cors', 'If add this option, added cors setting to all http event.')
+  .option('-O, --options-method', 'If add this option, added cors setting to get http event, and added OPTIONS method to api path that including other http method.')
   .parse(process.argv);
 
   const options = {
@@ -34,7 +38,7 @@ module.exports.exec = () => {
     basePath: (commander.basePath) ? commander.basePath : false,
     force: (commander.force) ? commander.force : false,
     cors: (commander.cors) ? commander.cors : false,
-    optionsMethod: (commander.optionsMethod) ? commander.optionsMethod : false
+    optionsMethod: (commander.optionsMethod) ? commander.optionsMethod : false,
   };
 
   Promise.resolve()

--- a/src/convert-swagger-to-configs.js
+++ b/src/convert-swagger-to-configs.js
@@ -15,18 +15,21 @@ const swaggerToDefinitions = (swagger, options) => {
     Object.keys(swagger.paths[path]).forEach(method => {
       definitions.push({
         path: path,
-        method: method,
+        method: method.toLowerCase(),
         methodObject: swagger.paths[path][method]
       });
+    });
 
-      if (options.optionsMethod) {
+    if (options.optionsMethod) {
+      const filtered = Object.keys(swagger.paths[path]).filter(method => (method.toLowerCase() !== 'get'));
+      if (filtered.length > 0) {
         definitions.push({
           path: path,
           method: 'options',
-          methodObject: swagger.paths[path][method]
+          methodObject: swagger.paths[path][filtered[0]]
         });
       }
-    });
+    }
   });
 
   return definitions;
@@ -56,12 +59,12 @@ const definitionToConfig = (definition, options) => {
   const httpEvent = {
     http: {
       path: path,
-      method: definition.method.toLowerCase(),
+      method: definition.method,
       integration: 'lambda-proxy'
     }
   };
 
-  if (options.cors && !options.options) {
+  if (options.cors || (options.optionsMethod && (definition.method === 'get'))) {
     httpEvent.http['cors'] = true;
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ describe('sis', () => {
 
   describe('interface testing', () => {
     before(() => {
-      const command = `${appRoot.path}/bin/sis -i test/swagger.yaml -c test/serverless.common.yml -S sis -B -O -f -o test/src`;
+      const command = `${appRoot.path}/bin/sis -i test/swagger.yaml -c test/serverless.common.yml -S sis -o test/src -f -O -B`;
       childProcess.execSync(command);
     });
 
@@ -46,7 +46,7 @@ describe('sis', () => {
     });
 
     after(() => {
-      return del(path.resolve(appRoot.path, './test/src'));
+      // return del(path.resolve(appRoot.path, './test/src'));
     });
   });
 


### PR DESCRIPTION
`--options-methodw`を有効にした際に、一般的にプリフライトリクエストが行われない、またはレスポンスヘッダの操作が少ない`GET`メソッドについては、関数定義を出力するのではなく、`cors: true`を付与するように修正した。
Serverless 1.5以下のバージョンによっては、出力関数が60までの制約があるため。