### PR TITLE
Add OpenAPI 3.0 support

### DIFF
--- a/lib/convert-swagger-to-configs.js
+++ b/lib/convert-swagger-to-configs.js
@@ -13,24 +13,28 @@ module.exports = function (swagger, options) {
 var swaggerToDefinitions = function swaggerToDefinitions(swagger, options) {
   var definitions = [];
 
-  Object.keys(swagger.paths).forEach(function (path) {
-    Object.keys(swagger.paths[path]).forEach(function (method) {
+  swagger.paths.getItems().forEach(function (pathItem) {
+    var path = pathItem.path();
+    var methodNames = Object.keys(pathItem).filter(function (k) {
+      return !k.startsWith("_");
+    });
+    methodNames.forEach(function (method) {
       definitions.push({
         path: path,
         method: method.toLowerCase(),
-        methodObject: swagger.paths[path][method]
+        methodObject: pathItem[method]
       });
     });
 
     if (options.optionsMethod) {
-      var filtered = Object.keys(swagger.paths[path]).filter(function (method) {
+      var filtered = methodNames.filter(function (method) {
         return method.toLowerCase() !== 'get';
       });
       if (filtered.length > 0) {
         definitions.push({
           path: path,
           method: 'options',
-          methodObject: swagger.paths[path][filtered[0]]
+          methodObject: pathItem[filtered[0]]
         });
       }
     }

--- a/lib/load-swagger.js
+++ b/lib/load-swagger.js
@@ -2,8 +2,11 @@
 
 var path = require('path');
 var fs = require('graceful-fs');
-var swaggerParser = require('swagger-parser');
+var yaml = require('js-yaml');
+var openapiParser = require('oai-ts-core');
 var appRoot = require('app-root-path');
+
+var parser = new openapiParser.OasLibraryUtils();
 
 module.exports = function (options) {
   return Promise.resolve().then(function () {
@@ -28,10 +31,11 @@ module.exports = function (options) {
           return;
         }
 
-        resole(path.resolve(appRoot.path, filtered[0]));
+        resolve(path.resolve(appRoot.path, filtered[0]));
       });
     });
   }).then(function (filePath) {
-    return swaggerParser.parse(filePath);
+    var yamlContent = yaml.safeLoad(fs.readFileSync(filePath));
+    return parser.createDocument(yamlContent);
   });
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "graceful-fs": "^4.1.10",
     "js-yaml": "^3.6.1",
     "serverless": "^1.9.0",
-    "swagger-parser": "^3.4.1"
+    "oai-ts-core": "^0.2.13"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/src/convert-swagger-to-configs.js
+++ b/src/convert-swagger-to-configs.js
@@ -11,22 +11,24 @@ module.exports = (swagger, options) => mergeConfigs(
 const swaggerToDefinitions = (swagger, options) => {
   const definitions = [];
 
-  Object.keys(swagger.paths).forEach(path => {
-    Object.keys(swagger.paths[path]).forEach(method => {
+  swagger.paths.getItems().forEach(pathItem => {
+    const path = pathItem.path();
+    const methodNames = Object.keys(pathItem).filter(k => !k.startsWith("_"));
+    methodNames.forEach(method => {
       definitions.push({
         path: path,
         method: method.toLowerCase(),
-        methodObject: swagger.paths[path][method]
+        methodObject: pathItem[method]
       });
     });
 
     if (options.optionsMethod) {
-      const filtered = Object.keys(swagger.paths[path]).filter(method => (method.toLowerCase() !== 'get'));
+      const filtered = methodNames.filter(method => (method.toLowerCase() !== 'get'));
       if (filtered.length > 0) {
         definitions.push({
           path: path,
           method: 'options',
-          methodObject: swagger.paths[path][filtered[0]]
+          methodObject: pathItem[filtered[0]]
         });
       }
     }

--- a/src/load-swagger.js
+++ b/src/load-swagger.js
@@ -2,8 +2,11 @@
 
 const path = require('path');
 const fs = require('graceful-fs');
-const swaggerParser = require('swagger-parser');
+const yaml = require('js-yaml');
+const openapiParser = require('oai-ts-core');
 const appRoot = require('app-root-path');
+
+const parser = new openapiParser.OasLibraryUtils();
 
 module.exports = options => Promise.resolve()
 .then(() => {
@@ -25,8 +28,11 @@ module.exports = options => Promise.resolve()
         return;
       }
 
-      resole(path.resolve(appRoot.path, filtered[0]));
+      resolve(path.resolve(appRoot.path, filtered[0]));
     });
   });
 })
-.then(filePath => swaggerParser.parse(filePath));
+.then(filePath => {
+    const yamlContent = yaml.safeLoad(fs.readFileSync(filePath));
+    return parser.createDocument(yamlContent);
+});

--- a/test/index.js
+++ b/test/index.js
@@ -11,43 +11,49 @@ const appRoot = require('app-root-path');
 
 describe('sis', () => {
 
-  describe('interface testing', () => {
-    before(() => {
-      const command = `${appRoot.path}/bin/sis -i test/swagger.yaml -c test/serverless.common.yml -S sis -o test/src -f -O -B`;
-      childProcess.execSync(command);
-    });
+  const swaggerVersions = [
+      {"name": "Swagger 2.0 (legacy)", "specFile":"test/swagger.yaml"},
+      {"name": "OpenAPI 3.0", "specFile":"test/openapi30.yaml"}
+  ];
 
-    it('Should generate authentication service.', (done) => {
-      fs.readdir(path.resolve(appRoot.path, './test/src/authentication'), (error, results) => {
-        assert.ok(results.some((result) => {
-          return (result === 'serverless.yml');
-        }));
-
-        assert.ok(results.some((result) => {
-          return (result === 'handler.js');
-        }));
-
-        done();
+  swaggerVersions.forEach(swaggerVersion => {
+    describe(`${swaggerVersion.name}: interface testing`, () => {
+      before(() => {
+        const command = `${appRoot.path}/bin/sis -i ${swaggerVersion.specFile} -c test/serverless.common.yml -S sis -o test/src -f -O -B`;
+        childProcess.execSync(command);
       });
-    });
 
-    it('Should generate test service.', (done) => {
-      fs.readdir(path.resolve(appRoot.path, './test/src/test'), (error, results) => {
-        assert.ok(results.some((result) => {
-          return (result === 'serverless.yml');
-        }));
+      it('Should generate authentication service.', (done) => {
+        fs.readdir(path.resolve(appRoot.path, './test/src/authentication'), (error, results) => {
+          assert.ok(results.some((result) => {
+            return (result === 'serverless.yml');
+          }));
 
-        assert.ok(results.some((result) => {
-          return (result === 'handler.js');
-        }));
+          assert.ok(results.some((result) => {
+            return (result === 'handler.js');
+          }));
 
-        done();
+          done();
+        });
       });
-    });
 
-    after(() => {
-      // return del(path.resolve(appRoot.path, './test/src'));
+      it('Should generate test service.', (done) => {
+        fs.readdir(path.resolve(appRoot.path, './test/src/test'), (error, results) => {
+          assert.ok(results.some((result) => {
+            return (result === 'serverless.yml');
+          }));
+
+          assert.ok(results.some((result) => {
+            return (result === 'handler.js');
+          }));
+
+          done();
+        });
+      });
+
+      after(() => {
+        return del(path.resolve(appRoot.path, './test/src'));
+      });
     });
   });
-
 });

--- a/test/index.js
+++ b/test/index.js
@@ -12,19 +12,19 @@ const appRoot = require('app-root-path');
 describe('sis', () => {
 
   const swaggerVersions = [
-      {"name": "Swagger 2.0 (legacy)", "specFile":"test/swagger.yaml"},
-      {"name": "OpenAPI 3.0", "specFile":"test/openapi30.yaml"}
+      {"name": "Swagger 2.0 (legacy)", "specFile":"test/swagger.yaml", "outDir":"test/src/swagger20"},
+      {"name": "OpenAPI 3.0", "specFile":"test/openapi30.yaml", "outDir":"test/src/openapi30"}
   ];
 
   swaggerVersions.forEach(swaggerVersion => {
     describe(`${swaggerVersion.name}: interface testing`, () => {
       before(() => {
-        const command = `${appRoot.path}/bin/sis -i ${swaggerVersion.specFile} -c test/serverless.common.yml -S sis -o test/src -f -O -B`;
+        const command = `${appRoot.path}/bin/sis -i ${swaggerVersion.specFile} -c test/serverless.common.yml -S sis -o ${swaggerVersion.outDir} -f -O -B`;
         childProcess.execSync(command);
       });
 
       it('Should generate authentication service.', (done) => {
-        fs.readdir(path.resolve(appRoot.path, './test/src/authentication'), (error, results) => {
+        fs.readdir(path.resolve(appRoot.path, `${swaggerVersion.outDir}/authentication`), (error, results) => {
           assert.ok(results.some((result) => {
             return (result === 'serverless.yml');
           }));
@@ -38,7 +38,7 @@ describe('sis', () => {
       });
 
       it('Should generate test service.', (done) => {
-        fs.readdir(path.resolve(appRoot.path, './test/src/test'), (error, results) => {
+        fs.readdir(path.resolve(appRoot.path, `${swaggerVersion.outDir}/test`), (error, results) => {
           assert.ok(results.some((result) => {
             return (result === 'serverless.yml');
           }));
@@ -52,7 +52,7 @@ describe('sis', () => {
       });
 
       after(() => {
-        return del(path.resolve(appRoot.path, './test/src'));
+        return del(path.resolve(appRoot.path, swaggerVersion.outDir));
       });
     });
   });

--- a/test/openapi30.yaml
+++ b/test/openapi30.yaml
@@ -1,0 +1,308 @@
+openapi: '3.0.0'
+info:
+  version: 1.0.0
+  title: Serverless Import Swagger
+  description: Test Swagger Spec
+paths:
+  /authentication/signup:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthenticationSignupParams"
+      tags:
+        - sls-authentication
+      responses:
+        200:
+          description: Register success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationSignupResponse"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /authentication/confirm-signup:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthenticationConfirmSignupParams"
+      tags:
+        - sls-authentication
+      responses:
+        200:
+          description: Confirm signup success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationConfirmSignupResponse"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /authentication/signin/email:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthenticationSigninParams"
+      tags:
+        - sls-authentication
+      responses:
+        200:
+          description: Signin success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthenticationSigninResponse"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /test:
+    get:
+      tags:
+        - sls-test
+      responses:
+        200:
+          description: Request Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestResponse"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /test/{id}:
+    get:
+      tags:
+        - sls-test
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Request Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestResponse"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /test/{testId}/comments/users:
+    get:
+      tags:
+        - sls-test
+      parameters:
+        - name: testId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Request Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestResponse"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /test/{testId}/users/{userId}/comments:
+    get:
+      tags:
+        - sls-test
+      parameters:
+        - name: testId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Request Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestResponse"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /test/{testId}/users/{userId}/comments/{commentId}:
+    get:
+      tags:
+        - sls-test
+      parameters:
+        - name: testId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: commentId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Request Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestResponse"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /user/testings/{testingId}/categories/{categorieId}/comments:
+    get:
+      tags:
+        - sls-test
+      parameters:
+        - name: testingId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: categorieId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Request Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestResponse"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+components:
+  schemas:
+    AuthenticationSignupParams:
+      type: object
+      properties:
+        email:
+          type: string
+        password:
+          type: string
+          format: password
+    AuthenticationSignupResponseData:
+      type: object
+      properties:
+        username:
+          type: string
+    AuthenticationSignupResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+        data:
+          $ref: "#/components/schemas/AuthenticationSignupResponseData"
+        message:
+          type: string
+  
+    AuthenticationConfirmSignupParams:
+      type: object
+      properties:
+        username:
+          type: string
+        confirmationCode:
+          type: string
+    AuthenticationConfirmSignupResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+        message:
+          type: string
+  
+    AuthenticationSigninParams:
+      type: object
+      properties:
+        email:
+          type: string
+        passwprd:
+          type: string
+          format: password
+    AuthenticationSigninResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+        message:
+          type: string
+  
+    Test:
+      type: object
+      properties:
+        key:
+          type: string
+    TestResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+        data:
+          $ref: "#/components/schemas/Test"
+        message:
+          type: string
+  
+    Error:
+      type: object
+      properties:
+        code:
+          type: integer
+        message:
+          type: string


### PR DESCRIPTION
This PR adds OpenAPI 3.0 support to close #12. It also closes #13 since it is required during test.

OpenAPI parser is replaced with the alternative one (https://github.com/Apicurio/oai-ts-core) which can parse both OpenAPI 2.0 (Swagger 2.0) and 3.0,  because `swagger-parser` does not support OpenAPI 3.0 yet (see: https://github.com/BigstickCarpet/swagger-parser/issues/72)

Note: The changes due to new parser seems very trivial, to my surprise. This means that parser can be `swagger-parser` again, once it supports OpenAPI 3.0, if you prefer the library. 