### PR TITLE
Fix #19: Update dependencies to fix security issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
     "deepmerge": "^1.3.2",
     "graceful-fs": "^4.1.10",
     "js-yaml": "^3.6.1",
-    "serverless": "^1.9.0",
+    "serverless": "^1.30.1",
     "swagger-parser": "^3.4.1"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-preset-latest": "^6.16.0",
     "del": "^2.2.2",
-    "mocha": "^3.2.0",
+    "mocha": "^5.2.0",
     "power-assert": "^1.4.2"
   },
   "scripts": {


### PR DESCRIPTION
`serverless` and `mocha` are updated to resolve vulnerabilities (#19) that `npm audit` raises.

I did check which dependencies may have vulnerabilities, using the below commands.

```bash
$ rm package-lock.json
$ npm install --package-lock-only
$ npm audit
```

I did test by
```bash
$ npm test
```








