### PR TITLE
Feature: Option to name a function from operationId.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ jspm_packages
 # Optional REPL history
 .node_repl_history
 
-test/src
+test/**/src

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -23,7 +23,9 @@ module.exports.exec = function () {
   // Base path mode settings.
   .option('-B, --base-path', 'If add this option, run in a mode of dividing a service by a api base path.')
   // CORS and options settings.
-  .option('-C, --cors', 'If add this option, added cors setting to all http event.').option('-O, --options-method', 'If add this option, added cors setting to get http event, and added OPTIONS method to api path that including other http method.').parse(process.argv);
+  .option('-C, --cors', 'If add this option, added cors setting to all http event.').option('-O, --options-method', 'If add this option, added cors setting to get http event, and added OPTIONS method to api path that including other http method.')
+  // Others
+  .option('--operation-id', 'If this option is added and an API has operationId, the function is named from operationId.').parse(process.argv);
 
   var options = {
     input: commander.input ? commander.input : 'swagger.yaml',
@@ -34,6 +36,7 @@ module.exports.exec = function () {
     basePath: commander.basePath ? commander.basePath : false,
     force: commander.force ? commander.force : false,
     cors: commander.cors ? commander.cors : false,
+    operationId: commander.operationId ? commander.operationId : false,
     optionsMethod: commander.optionsMethod ? commander.optionsMethod : false
   };
 

--- a/lib/convert-swagger-to-configs.js
+++ b/lib/convert-swagger-to-configs.js
@@ -97,6 +97,10 @@ var extractServiceName = function extractServiceName(definition, options) {
 var extractFunctionName = function extractFunctionName(definition, options) {
   var method = [definition.method];
 
+  if (options.operationId && typeof definition.operationId === 'string') {
+    return definition.operationId;
+  }
+
   var resources = definition.path.split('/').filter(function (w) {
     return w.length > 0;
   }).filter(function (w, i) {

--- a/lib/convert-swagger-to-configs.js
+++ b/lib/convert-swagger-to-configs.js
@@ -97,8 +97,8 @@ var extractServiceName = function extractServiceName(definition, options) {
 var extractFunctionName = function extractFunctionName(definition, options) {
   var method = [definition.method];
 
-  if (options.operationId && typeof definition.operationId === 'string') {
-    return definition.operationId;
+  if (options.operationId && definition.methodObject && typeof definition.methodObject.operationId === 'string') {
+    return definition.methodObject.operationId;
   }
 
   var resources = definition.path.split('/').filter(function (w) {

--- a/lib/convert-swagger-to-configs.js
+++ b/lib/convert-swagger-to-configs.js
@@ -150,3 +150,4 @@ var mergeConfigs = function mergeConfigs(configs) {
     return merged;
   });
 };
+module.exports._extractFunctionName = extractFunctionName;

--- a/package.json
+++ b/package.json
@@ -25,10 +25,13 @@
     "power-assert": "^1.4.2",
     "url-parse": "^1.4.3"
   },
+  "directories": {
+    "test": "test"
+  },
   "scripts": {
     "build": "babel src --out-dir lib",
     "pretest": "npm run build",
-    "test": "mocha --timeout 5000 ./test/index.js"
+    "test": "mocha --timeout 5000 --recursive"
   },
   "repository": {
     "type": "git",

--- a/src/cli.js
+++ b/src/cli.js
@@ -27,6 +27,8 @@ module.exports.exec = () => {
   // CORS and options settings.
   .option('-C, --cors', 'If add this option, added cors setting to all http event.')
   .option('-O, --options-method', 'If add this option, added cors setting to get http event, and added OPTIONS method to api path that including other http method.')
+  // Others
+  .option('--operation-id', 'If this option is added and an API has operationId, the function is named from operationId.')
   .parse(process.argv);
 
   const options = {
@@ -38,6 +40,7 @@ module.exports.exec = () => {
     basePath: (commander.basePath) ? commander.basePath : false,
     force: (commander.force) ? commander.force : false,
     cors: (commander.cors) ? commander.cors : false,
+    operationId: (commander.operationId) ? commander.operationId : false,
     optionsMethod: (commander.optionsMethod) ? commander.optionsMethod : false,
   };
 

--- a/src/convert-swagger-to-configs.js
+++ b/src/convert-swagger-to-configs.js
@@ -87,6 +87,10 @@ const extractServiceName = (definition, options) => {
 const extractFunctionName = (definition, options) => {
   const method = [definition.method];
 
+  if (options.operationId && typeof definition.operationId === 'string') {
+    return definition.operationId;
+  }
+  
   const resources = definition.path
   .split('/')
   .filter(w => (w.length > 0))

--- a/src/convert-swagger-to-configs.js
+++ b/src/convert-swagger-to-configs.js
@@ -136,3 +136,4 @@ const mergeConfigs = configs => {
     return merged;
   });
 };
+module.exports._extractFunctionName = extractFunctionName;

--- a/src/convert-swagger-to-configs.js
+++ b/src/convert-swagger-to-configs.js
@@ -87,8 +87,8 @@ const extractServiceName = (definition, options) => {
 const extractFunctionName = (definition, options) => {
   const method = [definition.method];
 
-  if (options.operationId && typeof definition.operationId === 'string') {
-    return definition.operationId;
+  if (options.operationId && definition.methodObject && typeof definition.methodObject.operationId === 'string') {
+    return definition.methodObject.operationId;
   }
   
   const resources = definition.path

--- a/test/integration/operation-id/index.js
+++ b/test/integration/operation-id/index.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const assert = require('power-assert');
+
+const del = require('del');
+const childProcess = require('child_process');
+const path = require('path');
+const jsyaml = require('js-yaml');
+const fs = require('graceful-fs');
+const appRoot = require('app-root-path');
+
+describe('operation-id', () => {
+
+  const basedir = 'test/integration/operation-id';
+  const swaggerVersions = [
+      {'name': 'Swagger 2.0 (legacy)', 'specFile': `${basedir}/swagger.yaml`, 'outDir':`${basedir}/src/swagger20}`},
+      {'name': 'OpenAPI 3.0', 'specFile':`${basedir}/openapi30.yaml`, 'outDir':`${basedir}/src/openapi30`}
+  ];
+
+  swaggerVersions.forEach(swaggerVersion => {
+    describe(`${swaggerVersion.name}`, () => {
+      let serviceDir;
+
+      before(() => {
+        const command = `${appRoot.path}/bin/sis --operation-id -i ${swaggerVersion.specFile} -c ${basedir}/serverless.common.yml -o ${swaggerVersion.outDir} -f`;
+        childProcess.execSync(command);
+        serviceDir = path.resolve(appRoot.path, `${swaggerVersion.outDir}/test`);
+      });
+
+      it('should generate test service.', (done) => {
+        fs.readdir(serviceDir, (error, results) => {
+          assert.ok(results.includes('serverless.yml'));
+          assert.ok(results.includes('handler.js'));
+          done();
+        });
+      });
+
+      it('should name a function using operationId', (done) => {
+        const generatedYamlFile = path.resolve(serviceDir, 'serverless.yml');
+        const yaml = jsyaml.safeLoad(fs.readFileSync(generatedYamlFile, 'utf8'));
+        const functionNames = Object.keys(yaml.functions);
+        assert.deepEqual(functionNames, ['getCommentsWithTesIdUseId', 'myName']);
+        done();
+      });
+
+      after(() => {
+        return del(path.resolve(appRoot.path, swaggerVersion.outDir));
+      });
+    });
+  });
+});

--- a/test/integration/operation-id/openapi30.yaml
+++ b/test/integration/operation-id/openapi30.yaml
@@ -1,0 +1,15 @@
+openapi: '3.0.0'
+info:
+  version: 1.0.0
+  title: Serverless Import Swagger
+  description: Test Swagger Spec
+paths:
+  /test/{testId}/users/{userId}/comments:
+    get:
+      tags:
+        - sls-test
+  /test/{testId}/users:
+    get:
+      operationId: myName
+      tags:
+        - sls-test

--- a/test/integration/operation-id/serverless.common.yml
+++ b/test/integration/operation-id/serverless.common.yml
@@ -1,0 +1,5 @@
+provider:
+  name: aws
+  runtime: nodejs4.3
+  stage: testing
+  region: ap-northeast-1

--- a/test/integration/operation-id/swagger.yaml
+++ b/test/integration/operation-id/swagger.yaml
@@ -1,0 +1,15 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Serverless Import Swagger
+  description: Test Swagger Spec
+paths:
+  /test/{testId}/users/{userId}/comments:
+    get:
+      tags:
+        - sls-test
+  /test/{testId}/users:
+    get:
+      operationId: myName
+      tags:
+        - sls-test

--- a/test/unit/convert-swagger-to-config.test.js
+++ b/test/unit/convert-swagger-to-config.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const assert = require('power-assert');
+const converter = require('../../lib/convert-swagger-to-configs');
+
+describe('convert-swagger-to-configs', () => {
+  
+  describe('extractFunctionName', () => {
+    describe('default', () => {
+      const option = {};
+      
+      it('should throw if method is null', () => {
+        const definition = {
+          method: 'hello',
+          path: null,
+        };
+        assert.throws(() => converter._extractFunctionName(definition, option));
+      });
+
+      it('should name if path is root', () => {
+        const definition = {
+          method: 'get',
+          path: '/',
+        };
+        assert.equal(converter._extractFunctionName(definition, option), 'get');
+      });
+
+      it('should concatenate method and paths to create name', () => {
+        const definition = {
+          method: 'get',
+          path: '/foo/bar',
+        };
+        assert.equal(converter._extractFunctionName(definition, option), 'getFooBar');
+      });
+
+      it('should convert snake_case in paths to PascalCase, but preserve _ in method', () => {
+        const definition = {
+          method: 'hello_world',
+          path: '/i_am_snake/alreadyCamel',
+        };
+        assert.equal(converter._extractFunctionName(definition, option), 'hello_worldIAmSnakeAlreadyCamel');
+      });
+
+      it('should extract path parameter and convert it to PascalCase of 3-chars words', () => {
+        const definition = {
+          method: 'get',
+          path: '/foo/bar/{very_long_path}',
+        };
+        assert.equal(converter._extractFunctionName(definition, option), 'getFooBarWithVerLonPat')
+      });
+
+      it('should use the non-parametric paths just after the last path parameter', () => {
+        const definition = {
+          method: 'get',
+          path: '/foo/{user_id}/bar/buz',
+        };
+        assert.equal(converter._extractFunctionName(definition, option), 'getBarBuzWithUseId')
+      });
+
+      it('should concatenates 2 or more path parameter without separator', () => {
+        const definition = {
+          method: 'get',
+          path: '/foo/bar/{user_id}/buz/{some_key}/fuga/hoge/{another_key}',
+        };
+        assert.equal(converter._extractFunctionName(definition, option), 'getFugaHogeWithUseIdSomKeyAnoKey')
+      });
+    });
+    
+    describe('options', () => {
+      describe('base-path', () => {
+        it('should skip the first path', () => {
+          const option = {
+            basePath: true
+          };
+
+          const definition1 = {
+            method: 'get',
+            path: '/base/foo/bar',
+          };
+          assert.equal(converter._extractFunctionName(definition1, option), 'getFooBar');
+
+          const definition2 = {
+            method: 'post',
+            path: '/base/another/more',
+          };
+          assert.equal(converter._extractFunctionName(definition2, option), 'postAnotherMore')
+        });
+      });
+    });
+  });
+});

--- a/test/unit/convert-swagger-to-config.test.js
+++ b/test/unit/convert-swagger-to-config.test.js
@@ -104,7 +104,9 @@ describe('convert-swagger-to-configs', () => {
           const definition1 = {
             method: 'get',
             path: '/foo/bar',
-            operationId: 42,
+            methodObject: {
+              operationId: 42,
+            }
           };
           assert.equal(converter._extractFunctionName(definition1, option), 'getFooBar');
         });
@@ -113,7 +115,9 @@ describe('convert-swagger-to-configs', () => {
           const definition1 = {
             method: 'get',
             path: '/foo/bar',
-            operationId: 'myName',
+            methodObject: {
+              operationId: 'myName',
+            }
           };
           assert.equal(converter._extractFunctionName(definition1, option), 'myName');
         });

--- a/test/unit/convert-swagger-to-config.test.js
+++ b/test/unit/convert-swagger-to-config.test.js
@@ -86,6 +86,38 @@ describe('convert-swagger-to-configs', () => {
           assert.equal(converter._extractFunctionName(definition2, option), 'postAnotherMore')
         });
       });
+
+      describe('operation-id', () => {
+        const option = {
+          operationId: true
+        };
+
+        it('should fallback to default name if operationId is not defined', () => {
+          const definition1 = {
+            method: 'get',
+            path: '/foo/bar',
+          };
+          assert.equal(converter._extractFunctionName(definition1, option), 'getFooBar');
+        });
+
+        it('should fallback to default name if operationId in definition is not a string', () => {
+          const definition1 = {
+            method: 'get',
+            path: '/foo/bar',
+            operationId: 42,
+          };
+          assert.equal(converter._extractFunctionName(definition1, option), 'getFooBar');
+        });
+        
+        it('should use operationId in definition as a name', () => {
+          const definition1 = {
+            method: 'get',
+            path: '/foo/bar',
+            operationId: 'myName',
+          };
+          assert.equal(converter._extractFunctionName(definition1, option), 'myName');
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Closes #23.

This is NOT a breaking change, since the new naming logic is used only if `--operation-id` option is present and API has `operationId`.
Otherwise the default naming logic is used.

