### PR TITLE
Add Travis CI for verifying PR do not break build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+dist: xenial
+language: node_js
+node_js:
+  - "6"
+  - "8"
+  - "10"
+sudo: false


### PR DESCRIPTION
This PR will add very basic configuration for Travis.


@AKIRA-MIYAKE 
I thinks it would be benefical for you to reduce your review cost by adding Travis CI.
Travis CI runs whenever PR get updated and verify that PR do not break build.
And it's free for OSS repository !!

Adding Travis CI requires the repository owner's permission, 
https://travis-ci.com/getting_started

If you think Travis CI is not necessary, feel free to reject this PR.





