### PR TITLE
Add authorizer option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -29,6 +29,8 @@ module.exports.exec = function () {
   .option('-B, --base-path', 'If add this option, run in a mode of dividing a service by a api base path.')
   // CORS and options settings.
   .option('-C, --cors', 'If add this option, added cors setting to all http event.').option('-O, --options-method', 'If add this option, added cors setting to get http event, and added OPTIONS method to api path that including other http method.')
+  // Authorization
+  .option('-a, --authorizer <name-or-arn>', 'Add custom authorizer to functions.')
   // Others
   .option('--operation-id', 'If this option is added and an API has operationId, the function is named from operationId.').parse(process.argv);
 
@@ -41,6 +43,7 @@ module.exports.exec = function () {
     basePath: commander.basePath ? commander.basePath : false,
     force: commander.force ? commander.force : false,
     cors: commander.cors ? commander.cors : false,
+    authorizer: commander.authorizer ? commander.authorizer : undefined,
     operationId: commander.operationId ? commander.operationId : false,
     optionsMethod: commander.optionsMethod ? commander.optionsMethod : false
   };

--- a/lib/convert-swagger-to-configs.js
+++ b/lib/convert-swagger-to-configs.js
@@ -80,6 +80,10 @@ var definitionToConfig = function definitionToConfig(definition, options) {
     httpEvent.http['cors'] = true;
   }
 
+  if (options.authorizer) {
+    httpEvent.http['authorizer'] = options.authorizer;
+  }
+
   var events = [httpEvent];
   var functions = {};
   functions[functionName] = { handler: handler, events: events };
@@ -157,3 +161,4 @@ var mergeConfigs = function mergeConfigs(configs) {
   });
 };
 module.exports._extractFunctionName = extractFunctionName;
+module.exports._definitionToConfig = definitionToConfig;

--- a/src/cli.js
+++ b/src/cli.js
@@ -33,6 +33,8 @@ module.exports.exec = () => {
   // CORS and options settings.
   .option('-C, --cors', 'If add this option, added cors setting to all http event.')
   .option('-O, --options-method', 'If add this option, added cors setting to get http event, and added OPTIONS method to api path that including other http method.')
+  // Authorization
+  .option('-a, --authorizer <name-or-arn>', 'Add custom authorizer to functions.')
   // Others
   .option('--operation-id', 'If this option is added and an API has operationId, the function is named from operationId.')
   .parse(process.argv);
@@ -46,6 +48,7 @@ module.exports.exec = () => {
     basePath: (commander.basePath) ? commander.basePath : false,
     force: (commander.force) ? commander.force : false,
     cors: (commander.cors) ? commander.cors : false,
+    authorizer: (commander.authorizer) ? commander.authorizer : undefined,
     operationId: (commander.operationId) ? commander.operationId : false,
     optionsMethod: (commander.optionsMethod) ? commander.optionsMethod : false,
   };

--- a/src/convert-swagger-to-configs.js
+++ b/src/convert-swagger-to-configs.js
@@ -72,6 +72,10 @@ const definitionToConfig = (definition, options) => {
     httpEvent.http['cors'] = true;
   }
 
+  if (options.authorizer) {
+    httpEvent.http['authorizer'] = options.authorizer;
+  }
+
   const events = [httpEvent];
   const functions = {};
   functions[functionName] = { handler, events };
@@ -143,3 +147,4 @@ const mergeConfigs = configs => {
   });
 };
 module.exports._extractFunctionName = extractFunctionName;
+module.exports._definitionToConfig = definitionToConfig;

--- a/test/unit/convert-swagger-to-config.test.js
+++ b/test/unit/convert-swagger-to-config.test.js
@@ -124,4 +124,24 @@ describe('convert-swagger-to-configs', () => {
       });
     });
   });
+
+  describe('definitionToConfig', () => {
+    describe('authorizer-arn', () => {
+      it('should add authorizer arn to generated function', () => {
+        const definition = {
+          method: 'get',
+          path: '/foo/bar',
+          methodObject: {
+            tags: ["sls-api"]
+          }
+        }
+        const option = {
+          apiPrefix: "sls",
+          authorizer: "arn:aws:lambda:*:*:function:fake-authorizer"
+        }
+        let config = converter._definitionToConfig(definition, option)
+        assert.equal(config.functions.getFooBar.events[0].http.authorizer, 'arn:aws:lambda:*:*:function:fake-authorizer')
+      });
+    });
+  });
 });


### PR DESCRIPTION
Provides the ability to associate custom authorizer function or arn to generated functions (https://serverless.com/framework/docs/providers/aws/events/apigateway/#http-endpoints-with-custom-authorizers)